### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/slack/AbstractSlackClientConnection.java
+++ b/src/main/java/io/kestra/plugin/slack/AbstractSlackClientConnection.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -25,6 +26,7 @@ public abstract class AbstractSlackClientConnection extends Task {
         title = "Slack token"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> token;
 
     // we only set in tests to redirect API calls to a mock server.

--- a/src/main/java/io/kestra/plugin/slack/AbstractSlackWebhookConnection.java
+++ b/src/main/java/io/kestra/plugin/slack/AbstractSlackWebhookConnection.java
@@ -26,39 +26,46 @@ public abstract class AbstractSlackWebhookConnection extends Task implements Run
         title = "Options",
         description = "The options to set to customize the HTTP client"
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     protected RequestOptions options;
 
     @Getter
     @Builder
     public static class RequestOptions {
         @Schema(title = "The time allowed to establish a connection to the server before failing.")
+        @PluginProperty(group = "execution")
         private final Property<Duration> connectTimeout;
 
         @Schema(title = "The maximum time allowed for reading data from the server before failing.")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Duration> readTimeout = Property.ofValue(Duration.ofSeconds(10));
 
         @Schema(title = "The time allowed for a read connection to remain idle before closing it.")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Duration> readIdleTimeout = Property.ofValue(Duration.of(5, ChronoUnit.MINUTES));
 
         @Schema(title = "The time an idle connection can remain in the client's connection pool before being closed.")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Duration> connectionPoolIdleTimeout = Property.ofValue(Duration.ofSeconds(0));
 
         @Schema(title = "The maximum content length of the response.")
         @Builder.Default
+        @PluginProperty(group = "execution")
         private final Property<Integer> maxContentLength = Property.ofValue(1024 * 1024 * 10);
 
         @Schema(title = "The default charset for the request.")
         @Builder.Default
+        @PluginProperty(group = "advanced")
         private final Property<Charset> defaultCharset = Property.ofValue(StandardCharsets.UTF_8);
 
         @Schema(
             title = "HTTP headers",
             description = "HTTP headers to include in the request"
         )
+        @PluginProperty(group = "advanced")
         public Property<Map<String, String>> headers;
     }
 }

--- a/src/main/java/io/kestra/plugin/slack/MessagePayloadInterface.java
+++ b/src/main/java/io/kestra/plugin/slack/MessagePayloadInterface.java
@@ -3,14 +3,17 @@ package io.kestra.plugin.slack;
 import io.kestra.core.models.property.Property;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.kestra.core.models.annotations.PluginProperty;
 
 public interface MessagePayloadInterface {
     @Schema(title = "Slack message payload")
+    @PluginProperty(group = "advanced")
     Property<String> getPayload();
 
     @Schema(
         title = "Message Text or JSON String",
         description = "The message content as a raw string. It can be plain text with markdown, or a JSON object. If not a valid JSON object, it is automatically wrapped in `{\"text\": \"...\"}`. This property is ignored if the `payload` property is set."
     )
+    @PluginProperty(group = "advanced")
     Property<String> getMessageText();
 }

--- a/src/main/java/io/kestra/plugin/slack/SlackTemplate.java
+++ b/src/main/java/io/kestra/plugin/slack/SlackTemplate.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -33,6 +34,7 @@ public abstract class SlackTemplate extends SlackIncomingWebhook {
             "[Current Webhooks](https://api.slack.com/messaging/webhooks)."
     )
     @Deprecated
+    @PluginProperty(group = "advanced")
     protected Property<String> channel;
 
     @Schema(
@@ -40,6 +42,7 @@ public abstract class SlackTemplate extends SlackIncomingWebhook {
         description = "This property works only with legacy webhook URLs, new Slack incoming webhook URLs are already tied to a specific username."
     )
     @Deprecated
+    @PluginProperty(group = "connection")
     protected Property<String> username;
 
     @Schema(
@@ -47,6 +50,7 @@ public abstract class SlackTemplate extends SlackIncomingWebhook {
         description = "This property works only with legacy webhook URLs, new Slack incoming webhook URLs are already tied to a specific icon URL."
     )
     @Deprecated
+    @PluginProperty(group = "connection")
     protected Property<String> iconUrl;
 
     @Schema(
@@ -54,17 +58,20 @@ public abstract class SlackTemplate extends SlackIncomingWebhook {
         description = "This property works only with legacy webhook URLs, new Slack incoming webhook URLs are already tied to a specific icon."
     )
     @Deprecated
+    @PluginProperty(group = "advanced")
     protected Property<String> iconEmoji;
 
     @Schema(
         title = "Template to use",
         hidden = true
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> templateUri;
 
     @Schema(
         title = "Map of variables to use for the message template"
     )
+    @PluginProperty(group = "advanced")
     protected Property<Map<String, Object>> templateRenderMap;
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/kestra/plugin/slack/app/canvases/AccessSet.java
+++ b/src/main/java/io/kestra/plugin/slack/app/canvases/AccessSet.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -54,6 +55,7 @@ public class AccessSet extends AbstractSlackClientConnection implements Runnable
         description = "Target canvas to update access for (e.g., `F1234567890`)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> canvasId;
 
     @Schema(
@@ -61,18 +63,21 @@ public class AccessSet extends AbstractSlackClientConnection implements Runnable
         description = "New access level to apply."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<AccessLevel> accessLevel;
 
     @Schema(
         title = "Channel IDs with access",
         description = "Channel IDs to update; cannot be set together with `userIds`."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> channelIds;
 
     @Schema(
         title = "User IDs with access",
         description = "User IDs to update; cannot be set together with `channelIds`."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> userIds;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/canvases/Create.java
+++ b/src/main/java/io/kestra/plugin/slack/app/canvases/Create.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -65,6 +66,7 @@ public class Create extends AbstractSlackClientConnection implements RunnableTas
         description = "Title displayed at the top of the canvas."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> title;
 
     @Schema(
@@ -72,6 +74,7 @@ public class Create extends AbstractSlackClientConnection implements RunnableTas
         description = "Map with `type` and `markdown`; only markdown content is supported by the Slack API."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Map<String, String>> documentContent;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/canvases/Delete.java
+++ b/src/main/java/io/kestra/plugin/slack/app/canvases/Delete.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -48,6 +49,7 @@ public class Delete extends AbstractSlackClientConnection implements RunnableTas
         description = "Canvas to delete; deletion is irreversible in Slack."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> canvasId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/canvases/Edit.java
+++ b/src/main/java/io/kestra/plugin/slack/app/canvases/Edit.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -101,6 +102,7 @@ public class Edit extends AbstractSlackClientConnection implements RunnableTask<
         description = "Canvas to edit; find it in the canvas URL or from creation output."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> canvasId;
 
     @Schema(
@@ -108,6 +110,7 @@ public class Edit extends AbstractSlackClientConnection implements RunnableTask<
         description = "Each entry must set `operation` plus `documentContent` or `titleContent`. Supported operations: insert_after, insert_before, insert_at_start, insert_at_end, replace, delete, rename."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<Map<String, Object>>> changes;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/canvases/SectionsLookup.java
+++ b/src/main/java/io/kestra/plugin/slack/app/canvases/SectionsLookup.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -57,6 +58,7 @@ public class SectionsLookup extends AbstractSlackClientConnection implements Run
         description = "Canvas to search for matching sections."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> canvasId;
 
     @Schema(
@@ -64,6 +66,7 @@ public class SectionsLookup extends AbstractSlackClientConnection implements Run
         description = "Map converted to Slack `Criteria`; supports fields such as `containsText` or `sectionTypes`."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Map<String, Object>> criteria;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/chats/AppendStream.java
+++ b/src/main/java/io/kestra/plugin/slack/app/chats/AppendStream.java
@@ -15,6 +15,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -115,6 +116,7 @@ public class AppendStream extends AbstractSlackClientConnection implements Runna
         description = "Channel ID or name where the stream was started."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Schema(
@@ -122,6 +124,7 @@ public class AppendStream extends AbstractSlackClientConnection implements Runna
         description = "Slack `ts` returned by StartStream."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> timestamp;
 
     @Schema(
@@ -129,6 +132,7 @@ public class AppendStream extends AbstractSlackClientConnection implements Runna
         description = "Additional markdown content appended to the stream."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> markdownText;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/chats/ChatInterface.java
+++ b/src/main/java/io/kestra/plugin/slack/app/chats/ChatInterface.java
@@ -5,21 +5,27 @@ import java.time.Instant;
 import io.kestra.core.models.property.Property;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.kestra.core.models.annotations.PluginProperty;
 
 public interface ChatInterface {
     @Schema(title = "Channel to send message", description = "Channel ID or name; can also be set inside the payload.")
+    @PluginProperty(group = "advanced")
     Property<String> getChannel();
 
     @Schema(title = "Thread timestamp to reply to", description = "Slack `ts` value for replying in a thread; must belong to the same channel.")
+    @PluginProperty(group = "advanced")
     Property<Instant> getTimestamp();
 
     @Schema(title = "Display username", description = "Overrides the bot's default display name for this message.")
+    @PluginProperty(group = "connection")
     Property<String> getUsername();
 
     @Schema(title = "Message icon URL", description = "HTTPS image used as icon when `iconEmoji` is not provided.")
+    @PluginProperty(group = "connection")
     Property<String> getIconUrl();
 
     @Schema(title = "Message icon emoji", description = "Emoji code (e.g., :wave:) that overrides `iconUrl`.")
+    @PluginProperty(group = "advanced")
     Property<String> getIconEmoji();
 
 }

--- a/src/main/java/io/kestra/plugin/slack/app/chats/Delete.java
+++ b/src/main/java/io/kestra/plugin/slack/app/chats/Delete.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -73,6 +74,7 @@ public class Delete extends AbstractSlackClientConnection implements RunnableTas
         description = "Channel ID or name where the target message exists."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> channel;
 
     @Schema(
@@ -80,6 +82,7 @@ public class Delete extends AbstractSlackClientConnection implements RunnableTas
         description = "Slack `ts` of the message; must belong to the specified channel."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<Instant> timestamp;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/chats/DeleteScheduled.java
+++ b/src/main/java/io/kestra/plugin/slack/app/chats/DeleteScheduled.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -74,6 +75,7 @@ public class DeleteScheduled extends AbstractSlackClientConnection implements Ru
         description = "Channel ID or name that holds the scheduled post."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> channel;
 
     @Schema(
@@ -81,6 +83,7 @@ public class DeleteScheduled extends AbstractSlackClientConnection implements Ru
         description = "Value returned by Schedule; uniquely identifies the pending post."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> scheduledMessageId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/chats/PostEphemeral.java
+++ b/src/main/java/io/kestra/plugin/slack/app/chats/PostEphemeral.java
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -84,6 +85,7 @@ public class PostEphemeral extends AbstractSlackClientConnection implements Runn
         title = "Recipient user ID",
         description = "User who sees the ephemeral message; must be a member of the channel (IDs usually start with `U`)."
     )
+    @PluginProperty(group = "main")
     private Property<String> user;
 
     private Property<String> payload;

--- a/src/main/java/io/kestra/plugin/slack/app/chats/Schedule.java
+++ b/src/main/java/io/kestra/plugin/slack/app/chats/Schedule.java
@@ -21,6 +21,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -93,6 +94,7 @@ public class Schedule extends AbstractSlackClientConnection implements RunnableT
         description = "Future time to post the message; the Instant is converted to epoch seconds for Slack."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<Instant> postAt;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/chats/StartStream.java
+++ b/src/main/java/io/kestra/plugin/slack/app/chats/StartStream.java
@@ -15,6 +15,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -100,30 +101,35 @@ public class StartStream extends AbstractSlackClientConnection implements Runnab
         title = "Channel for the stream",
         description = "Channel ID or name where the streaming message is posted."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> channel;
 
     @Schema(
         title = "Initial markdown content",
         description = "Markdown body to seed the streaming message."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> markdownText;
 
     @Schema(
         title = "Thread timestamp to reply to",
         description = "Slack `ts` to nest the stream inside an existing thread."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> timestamp;
 
     @Schema(
         title = "Recipient user ID",
         description = "Required when streaming into channels to target a specific user."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> recipientUserId;
 
     @Schema(
         title = "Recipient team ID",
         description = "Team ID for the recipient; required alongside `recipientUserId` for channel streams."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> recipientTeamId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/chats/StopStream.java
+++ b/src/main/java/io/kestra/plugin/slack/app/chats/StopStream.java
@@ -15,6 +15,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -129,6 +130,7 @@ public class StopStream extends AbstractSlackClientConnection implements Runnabl
         description = "Channel ID or name where the stream was started."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Schema(
@@ -136,24 +138,28 @@ public class StopStream extends AbstractSlackClientConnection implements Runnabl
         description = "Slack `ts` returned by StartStream."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> timestamp;
 
     @Schema(
         title = "Final markdown content",
         description = "Optional markdown appended before closing the stream."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> markdownText;
 
     @Schema(
         title = "Final Block Kit blocks",
         description = "JSON array string of blocks appended before closing."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> blocks;
 
     @Schema(
         title = "Final message metadata",
         description = "JSON object string attached to the closing message."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> metadata;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Archive.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Archive.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -48,6 +49,7 @@ public class Archive extends AbstractSlackClientConnection implements RunnableTa
         description = "Channel to archive; use the Slack channel ID (e.g., C123...)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Close.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Close.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -50,6 +51,7 @@ public class Close extends AbstractSlackClientConnection implements RunnableTask
         description = "DM or MPIM ID to close (e.g., D123..., G123...)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Create.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Create.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -50,6 +51,7 @@ public class Create extends AbstractSlackClientConnection implements RunnableTas
         description = "Lowercase letters, numbers, hyphens, underscores only; max 80 characters."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> name;
 
     @Schema(
@@ -57,12 +59,14 @@ public class Create extends AbstractSlackClientConnection implements RunnableTas
         description = "If true, creates a private channel; defaults to public."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> isPrivate = Property.ofValue(false);
 
     @Schema(
         title = "Team ID",
         description = "Encoded team ID required when using an org token."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> teamId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/History.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/History.java
@@ -27,6 +27,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -68,18 +69,21 @@ public class History extends AbstractSlackClientConnection implements RunnableTa
         description = "Channel whose history to export; Slack channel ID. To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Schema(
         title = "Oldest timestamp",
         description = "Inclusive lower bound (Instant) converted to Slack ts."
     )
+    @PluginProperty(group = "advanced")
     private Property<Instant> oldest;
 
     @Schema(
         title = "Latest timestamp",
         description = "Inclusive upper bound (Instant) converted to Slack ts."
     )
+    @PluginProperty(group = "advanced")
     private Property<Instant> latest;
 
     @Schema(
@@ -87,6 +91,7 @@ public class History extends AbstractSlackClientConnection implements RunnableTa
         description = "If true, returns thread messages as well; defaults to false."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> inclusive = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Info.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -49,6 +50,7 @@ public class Info extends AbstractSlackClientConnection implements RunnableTask<
         description = "Slack channel ID to describe (e.g., C123...)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Schema(
@@ -56,6 +58,7 @@ public class Info extends AbstractSlackClientConnection implements RunnableTask<
         description = "Set to true to include locale; defaults to false."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> includeLocale = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Invite.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Invite.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -52,6 +53,7 @@ public class Invite extends AbstractSlackClientConnection implements RunnableTas
         description = "Channel to invite users to (Slack channel ID). To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Schema(
@@ -59,6 +61,7 @@ public class Invite extends AbstractSlackClientConnection implements RunnableTas
         description = "List of Slack user IDs (U...) to add. To get a user ID, go to the user's profile, click the three dots, and select 'Copy member ID'."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> users;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Join.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Join.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -49,6 +50,7 @@ public class Join extends AbstractSlackClientConnection implements RunnableTask<
         description = "Channel to join; provide the Slack channel ID (e.g., C123...). To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Kick.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Kick.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -51,6 +52,7 @@ public class Kick extends AbstractSlackClientConnection implements RunnableTask<
         description = "Channel to remove the user from (Slack channel ID). To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Schema(
@@ -58,6 +60,7 @@ public class Kick extends AbstractSlackClientConnection implements RunnableTask<
         description = "Member ID to remove (e.g., U123...); user must currently be in the channel. To get a user ID, go to the user's profile, click the three dots, and select 'Copy member ID'."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> user;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Leave.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Leave.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -48,6 +49,7 @@ public class Leave extends AbstractSlackClientConnection implements RunnableTask
         description = "Channel to leave; provide the Slack channel ID. To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/List.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/List.java
@@ -25,6 +25,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -73,12 +74,14 @@ public class List extends AbstractSlackClientConnection implements RunnableTask<
         description = "If true, archived channels are filtered out. Default false."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> excludeArchived = Property.ofValue(false);
 
     @Schema(
         title = "Team ID",
         description = "Encoded team ID required when using an org token."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> teamId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Members.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Members.java
@@ -24,6 +24,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -65,6 +66,7 @@ public class Members extends AbstractSlackClientConnection implements RunnableTa
         description = "Channel whose members to list; provide the Slack channel ID. To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Open.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Open.java
@@ -16,6 +16,7 @@ import io.kestra.plugin.slack.app.models.ConversationOutput;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -63,12 +64,14 @@ public class Open extends AbstractSlackClientConnection implements RunnableTask<
         title = "User IDs to include",
         description = "One ID opens a DM; multiple IDs open an MPIM. Provide Slack user IDs (U...). To get a user ID, go to the user's profile, click the three dots, and select 'Copy member ID'."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> users;
 
     @Schema(
         title = "Existing IM/MPIM ID",
         description = "Resume a conversation by ID instead of passing users."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> channel;
 
     @Schema(
@@ -76,6 +79,7 @@ public class Open extends AbstractSlackClientConnection implements RunnableTask<
         description = "If true, return existing DM instead of creating a new one. Default false."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> returnIm = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Rename.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Rename.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -52,6 +53,7 @@ public class Rename extends AbstractSlackClientConnection implements RunnableTas
         description = "Channel to rename; Slack channel ID required. To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Schema(
@@ -59,6 +61,7 @@ public class Rename extends AbstractSlackClientConnection implements RunnableTas
         description = "Lowercase letters, numbers, hyphens, and underscores only; max 80 characters."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> name;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/SetPurpose.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/SetPurpose.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -50,6 +51,7 @@ public class SetPurpose extends AbstractSlackClientConnection implements Runnabl
         description = "Channel whose purpose to update; Slack channel ID. To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Schema(
@@ -57,6 +59,7 @@ public class SetPurpose extends AbstractSlackClientConnection implements Runnabl
         description = "New purpose text, maximum 250 characters."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> purpose;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/SetTopic.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/SetTopic.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -53,6 +54,7 @@ public class SetTopic extends AbstractSlackClientConnection implements RunnableT
         description = "Channel whose topic to update; Slack channel ID. To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Schema(
@@ -60,6 +62,7 @@ public class SetTopic extends AbstractSlackClientConnection implements RunnableT
         description = "New topic text, maximum 250 characters."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> topic;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/Unarchive.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/Unarchive.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -50,6 +51,7 @@ public class Unarchive extends AbstractSlackClientConnection implements Runnable
         description = "Channel to unarchive; must be provided as a Slack channel ID (e.g., C123...). To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> channel;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/core/Trigger.java
+++ b/src/main/java/io/kestra/plugin/slack/app/core/Trigger.java
@@ -113,14 +113,14 @@ public class Trigger extends AbstractWebhookTrigger implements TriggerOutput<Tri
     };
     private static final ObjectMapper MAPPER = JacksonMapper.ofJson().copy().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
-    @PluginProperty
+    @PluginProperty(group = "connection")
     @Schema(
         title = "Slack bot token",
         description = "Bot token for the installed app, rendered at runtime (typically starts with `xoxb-`)."
     )
     private Property<String> botToken;
 
-    @PluginProperty
+    @PluginProperty(group = "connection")
     @Schema(
         title = "Slack signing secret",
         description = "Secret used to verify Slack signatures on every webhook request; required for all Event API calls."

--- a/src/main/java/io/kestra/plugin/slack/app/files/Delete.java
+++ b/src/main/java/io/kestra/plugin/slack/app/files/Delete.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -70,6 +71,7 @@ public class Delete extends AbstractSlackClientConnection implements RunnableTas
         description = "Slack file ID to delete (e.g., F123...). Use Upload output or Slack API to obtain."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> fileId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/files/Info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/files/Info.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -74,6 +75,7 @@ public class Info extends AbstractSlackClientConnection implements RunnableTask<
         description = "Slack file ID (e.g., F123...); obtain from Upload output or Slack API."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> fileId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/files/Upload.java
+++ b/src/main/java/io/kestra/plugin/slack/app/files/Upload.java
@@ -102,41 +102,47 @@ public class Upload extends AbstractSlackClientConnection implements RunnableTas
         description = "Internal storage URI of the file to upload (inputs/outputs/other tasks)."
     )
     @NotNull
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "main")
     private Property<String> from;
 
     @Schema(
         title = "Target channels",
         description = "Channel IDs or names to share the file to; multiple allowed."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> channels;
 
     @Schema(title = "Filename")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> filename;
 
     @Schema(
         title = "File title",
         description = "Optional display title shown in Slack."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> title;
 
     @Schema(
         title = "Alt text",
         description = "Accessibility text, useful for images or visual content."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> altTxt;
 
     @Schema(
         title = "Snippet language",
         description = "Syntax highlighting label for code snippets (e.g., python, java, javascript)."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> snippetType;
 
     @Schema(
         title = "Thread timestamp",
         description = "Slack `ts` to post the file as a thread reply; requires matching channel and `chat:write`."
     )
+    @PluginProperty(group = "advanced")
     private Property<Instant> timestamp;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/reactions/Add.java
+++ b/src/main/java/io/kestra/plugin/slack/app/reactions/Add.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -78,6 +79,7 @@ public class Add extends AbstractSlackClientConnection implements RunnableTask<V
         description = "Channel ID or name where the target message lives. To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> channel;
 
     @Schema(
@@ -85,6 +87,7 @@ public class Add extends AbstractSlackClientConnection implements RunnableTask<V
         description = "Name without colons (e.g., thumbsup, white_check_mark, heart)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> name;
 
     @Schema(
@@ -92,6 +95,7 @@ public class Add extends AbstractSlackClientConnection implements RunnableTask<V
         description = "Slack `ts` of the message to react to."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<Instant> timestamp;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/reactions/Get.java
+++ b/src/main/java/io/kestra/plugin/slack/app/reactions/Get.java
@@ -27,6 +27,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -94,24 +95,28 @@ public class Get extends AbstractSlackClientConnection implements RunnableTask<G
         description = "Channel ID or name for the target message. To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> channel;
 
     @Schema(
         title = "File ID (optional)",
         description = "Use when retrieving reactions for a file."
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> file;
 
     @Schema(
         title = "File comment ID (optional)",
         description = "Use when retrieving reactions for a file comment."
     )
+    @PluginProperty(group = "advanced")
     protected Property<String> fileComment;
 
     @Schema(
         title = "Message timestamp (optional)",
         description = "Slack `ts` of the message; required when targeting a message."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Instant> timestamp;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/reactions/Remove.java
+++ b/src/main/java/io/kestra/plugin/slack/app/reactions/Remove.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -79,6 +80,7 @@ public class Remove extends AbstractSlackClientConnection implements RunnableTas
         description = "Channel ID or name where the target message lives. To get the channel ID, right click on the channel name in Slack and select 'Copy Link'. The ID is the last part of the URL."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> channel;
 
     @Schema(
@@ -86,6 +88,7 @@ public class Remove extends AbstractSlackClientConnection implements RunnableTas
         description = "Name without colons (e.g., thumbsup, white_check_mark, heart)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> name;
 
     @Schema(
@@ -93,6 +96,7 @@ public class Remove extends AbstractSlackClientConnection implements RunnableTas
         description = "Slack `ts` of the message to remove the reaction from."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<Instant> timestamp;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/users/Conversations.java
+++ b/src/main/java/io/kestra/plugin/slack/app/users/Conversations.java
@@ -25,6 +25,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -65,6 +66,7 @@ public class Conversations extends AbstractSlackClientConnection implements Runn
         title = "User ID (optional)",
         description = "User to query; defaults to the authenticated user."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> user;
 
     @Schema(
@@ -72,6 +74,7 @@ public class Conversations extends AbstractSlackClientConnection implements Runn
         description = "If true, archived conversations are omitted. Default false."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> excludeArchived = Property.ofValue(false);
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/slack/app/users/GetPresence.java
+++ b/src/main/java/io/kestra/plugin/slack/app/users/GetPresence.java
@@ -15,6 +15,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -49,6 +50,7 @@ public class GetPresence extends AbstractSlackClientConnection implements Runnab
         description = "User whose presence is requested."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> user;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/users/Info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/users/Info.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -49,6 +50,7 @@ public class Info extends AbstractSlackClientConnection implements RunnableTask<
         description = "Slack user ID to describe."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> user;
 
     @Schema(
@@ -56,6 +58,7 @@ public class Info extends AbstractSlackClientConnection implements RunnableTask<
         description = "If true, locale is returned. Default false."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> includeLocale = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/users/List.java
+++ b/src/main/java/io/kestra/plugin/slack/app/users/List.java
@@ -24,6 +24,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 import reactor.core.publisher.Flux;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -64,6 +65,7 @@ public class List extends AbstractSlackClientConnection implements RunnableTask<
         description = "If true, locale fields are included. Default false."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> includeLocale = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/users/LookupByEmail.java
+++ b/src/main/java/io/kestra/plugin/slack/app/users/LookupByEmail.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -49,6 +50,7 @@ public class LookupByEmail extends AbstractSlackClientConnection implements Runn
         description = "Workspace email to look up."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> email;
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/app/users/ProfileGet.java
+++ b/src/main/java/io/kestra/plugin/slack/app/users/ProfileGet.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -47,6 +48,7 @@ public class ProfileGet extends AbstractSlackClientConnection implements Runnabl
         title = "User ID (optional)",
         description = "Target user; defaults to the authenticated user."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> user;
 
     @Schema(
@@ -54,6 +56,7 @@ public class ProfileGet extends AbstractSlackClientConnection implements Runnabl
         description = "If true, includes labels for structured profile fields. Default false."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> includeLabels = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/slack/notifications/SlackIncomingWebhook.java
+++ b/src/main/java/io/kestra/plugin/slack/notifications/SlackIncomingWebhook.java
@@ -193,7 +193,7 @@ public class SlackIncomingWebhook extends AbstractSlackWebhookConnection impleme
         title = "Slack incoming webhook URL",
         description = "Check the <a href=\"https://api.slack.com/messaging/webhooks#create_a_webhook\">Create an Incoming Webhook</a> documentation for more details."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "connection")
     @NotEmpty
     private String url;
 


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712