### PR TITLE
fix(plugin-slack): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/slack/app/canvases/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/canvases/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack Canvases",
     description = "This sub-group of plugins contains tasks for Slack canvases.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )

--- a/src/main/java/io/kestra/plugin/slack/app/chats/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/chats/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack Chats",
     description = "This sub-group of plugins contains tasks for Slack chat messages and streams.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )

--- a/src/main/java/io/kestra/plugin/slack/app/conversations/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/conversations/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack Conversations",
     description = "This sub-group of plugins contains tasks for Slack conversations and channels.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )

--- a/src/main/java/io/kestra/plugin/slack/app/core/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/core/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack App",
     description = "This sub-group of plugins contains Slack app event triggers.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )

--- a/src/main/java/io/kestra/plugin/slack/app/files/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/files/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack Files",
     description = "This sub-group of plugins contains tasks for Slack files operations.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )

--- a/src/main/java/io/kestra/plugin/slack/app/models/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/models/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack Models",
     description = "This sub-group of plugins contains output models for Slack app tasks.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )

--- a/src/main/java/io/kestra/plugin/slack/app/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack App",
     description = "This sub-group of plugins contains Slack app event trigger and app token tasks.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )

--- a/src/main/java/io/kestra/plugin/slack/app/reactions/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/reactions/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack Reactions",
     description = "This sub-group of plugins contains tasks for Slack reactions.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )

--- a/src/main/java/io/kestra/plugin/slack/app/users/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/app/users/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack Users",
     description = "This sub-group of plugins contains tasks for Slack users.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )

--- a/src/main/java/io/kestra/plugin/slack/notifications/package-info.java
+++ b/src/main/java/io/kestra/plugin/slack/notifications/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Slack Notifications",
     description = "This sub-group of plugins contains tasks for Slack notifications.",
     categories = PluginSubGroup.PluginCategory.BUSINESS
 )


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while the metadata YAML uses a prefixed slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge