### PR TITLE
refactor: replace deprecated json filter with toJson

### DIFF
--- a/src/main/resources/slack-template.peb
+++ b/src/main/resources/slack-template.peb
@@ -15,7 +15,7 @@
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": {{ customMessage | json }}
+				"text": {{ customMessage | toJson }}
 			}
 		},
         {% endif %}
@@ -43,29 +43,29 @@
           "fields": [
               {
                   "title": "Namespace",
-                  "value": {{execution.namespace | json }},
+                  "value": {{execution.namespace | toJson }},
                   "short": true
               },
               {
                   "title": "Flow ID",
-                  "value": {{execution.flowId | json}},
+                  "value": {{execution.flowId | toJson}},
                   "short": true
               },
               {
                   "title": "Execution ID",
-                  "value": {{execution.id | json}},
+                  "value": {{execution.id | toJson}},
                   "short": true
               },
               {
                   "title": "Execution Status",
-                  "value": {{execution.state.current | json }},
+                  "value": {{execution.state.current | toJson }},
                   "short": true
               }
               {% if customFields is defined %}
               {% for entry in customFields %}
               ,{
-                  "title": {{entry.key | json}},
-                  "value": {{entry.value | json }},
+                  "title": {{entry.key | toJson}},
+                  "value": {{entry.value | toJson }},
                   "short": true
               }
               {% endfor %}
@@ -73,7 +73,7 @@
               ,
               {
                   "title": "Final task ID",
-                  "value": {{ lastTask.taskId | json }},
+                  "value": {{ lastTask.taskId | toJson }},
                   "short": true
               }
           ],

--- a/src/test/resources/flows/common/main-flow-that-fails.yaml
+++ b/src/test/resources/flows/common/main-flow-that-fails.yaml
@@ -2,4 +2,4 @@ id: main-flow-that-fails
 namespace: io.kestra.tests
 tasks:
   - id: failed
-    type: io.kestra.core.tasks.executions.Fail
+    type: io.kestra.plugin.core.execution.Fail

--- a/src/test/resources/slack.peb
+++ b/src/test/resources/slack.peb
@@ -5,7 +5,7 @@
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": {{ block.text | json }}
+                "text": {{ block.text | toJson }}
             }
         },
         {
@@ -13,7 +13,7 @@
             "fields": [
                 {
                     "type": "mrkdwn",
-                    "text": {{ block.field | json }}
+                    "text": {{ block.field | toJson }}
                 }
             ]
         },


### PR DESCRIPTION
Replaces the deprecated json Pebble filter with toJson